### PR TITLE
Fix pip install for Google Colab (Python 3.10.11)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,18 @@
 g2p-en == 2.1.0
+google-auth == 2.14.1
 inflect == 4.1.0
 librosa == 0.7.2
-matplotlib == 3.2.2
-numba == 0.48
-numpy == 1.19.0
-pypinyin==0.39.0
+matplotlib == 3.5.0
+numba == 0.56.4
+numpy == 1.23.5
+pypinyin == 0.39.0
 pyworld == 0.2.10
-PyYAML==5.4.1
-scikit-learn==0.23.2
-scipy == 1.5.0
-soundfile==0.10.3.post1
-tensorboard == 2.2.2
+PyYAML == 5.4.1
+scikit-learn == 1.2.2
+scipy == 1.10.1
+soundfile == 0.10.3.post1
+tensorboard == 2.12.2
 tgt == 1.4.4
-torch == 1.7.0
-tqdm==4.46.1
+torch == 2.0.0
+tqdm==4.48.0
 unidecode == 1.1.1


### PR DESCRIPTION
The master branch's requirements.txt file caused problems for Google Colab (noticed on 2023-04-27) because it now uses a newer version of Python (3.10.11), so this will resolve the issue. However, the Colab user will need to restart the runtime at one point during pip install.